### PR TITLE
chore(compose): persist rejuve-network attachment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       - mongo
     volumes:
       - ./logs:/app/logs
+    networks:
+      - default
+      - rejuve-network
     restart: unless-stopped
 
   redis:
@@ -69,3 +72,8 @@ volumes:
   vectordata:
   redis_data:
   mongo_data:
+
+networks:
+  default:
+  rejuve-network:
+    external: true


### PR DESCRIPTION
## Summary
- Attach the `app` service to `rejuve-network` (declared as external) in `docker-compose.yml`
- Prevents DNS issues where `mcp-app` was losing its cross-project connection after every `docker compose up --build`, requiring a manual `docker network connect rejuve-network mcp-app` to talk to auth-service / ai-assistant

## Why
Without this, after rebuilds `mcp-app` was occasionally getting attached to `ai-assistant_default`, which has a colliding `qdrant` and `redis` DNS alias on a different subnet, causing intermittent connection failures.

## Test plan
- [x] Pulled on hetzner: `mcp-xp_default` + `rejuve-network` both attached after `docker compose up -d`
- [x] `getent hosts qdrant` resolves to 172.29.0.x (not 192.168.0.x)
- [x] mcp-app can reach Galaxy via auth-service over rejuve-network

🤖 Generated with [Claude Code](https://claude.com/claude-code)