### PR TITLE
Split LLM config: provider NAME + SDK protocol dispatch, activate local models

### DIFF
--- a/app/bioblend_server/informer/utils.py
+++ b/app/bioblend_server/informer/utils.py
@@ -107,17 +107,13 @@ class LLMResponse:
         return providers[provider_name]
 
     def _instantiate(self, provider_name: str) -> LLMProvider:
-        """Build an LLMProvider from a config block, dispatching by `protocol:`.
-
-        Falls back to the block's `provider:` field for backward compat with
-        older configs that pre-date the protocol/name split.
-        """
+        """Build an LLMProvider from a config block, dispatching by `protocol:`."""
         block = self._get_provider_block(provider_name)
-        protocol_str = block.get('protocol') or block.get('provider')
+        protocol_str = block.get('protocol')
         if not protocol_str:
             raise ValueError(
-                f"Provider '{provider_name}' has neither 'protocol' nor "
-                "'provider' set; can't decide which SDK to use."
+                f"Provider '{provider_name}' has no 'protocol' set; "
+                "can't decide which SDK to use."
             )
         try:
             protocol = Protocol(protocol_str)

--- a/app/bioblend_server/informer/utils.py
+++ b/app/bioblend_server/informer/utils.py
@@ -14,15 +14,37 @@ from app.llm_provider import (
 
 load_dotenv()
 
-class TextProvider(Enum):
-    GEMINI = "gemini"
-    OPENAI = "openai"
-
-class EmbeddingProvider(Enum):
+# A Protocol identifies which client SDK/API shape a provider block speaks,
+# NOT its identity in the config. A single protocol can back many named
+# provider blocks (e.g. "openai" the OpenAI cloud, "local_llm" pointing at a
+# self-hosted vLLM, "local_embed" pointing at Ollama — all speak the OpenAI
+# protocol at different URLs).
+#
+# Config lookups now happen by provider NAME (arbitrary yaml key). The
+# `protocol:` field inside each block tells us which Provider class to
+# instantiate. This decouples "what SDK" from "what endpoint / role", which
+# is what let us swap only-embeddings to a local model without also having
+# to route chat through the same host.
+class Protocol(Enum):
     GEMINI = "gemini"
     OPENAI = "openai"
     HUGGINGFACE = "huggingface"
-    
+
+# Fallback: when a provider block doesn't declare `embedding_size:` we look
+# up the dim by embedding_model name. Keeps existing configs working without
+# a migration step; new configs should just set `embedding_size:` explicitly.
+_EMBEDDING_MODEL_DIMS: dict[str, int] = {
+    "embedding-001": 768,
+    "embedding-002": 1408,
+    "text-embedding-004": 768,
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "intfloat/e5-large-v2": 1024,
+    "mxbai-embed-large:latest": 1024,
+    "mxbai-embed-large": 1024,
+}
+
+
 class ReRankerModel(Enum):
     MS_MARCO_MINILM = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
@@ -48,62 +70,92 @@ class WorkflowHubScraperUrl(Enum):
     BASE_URL = "https://workflowhub.eu"
     TRS_BASE_URL = "https://workflowhub.eu/ga4gh/trs/v2"
     
-class EmbeddingModel(Enum):
-    """Defines supported embedding models and their vector sizes."""
-    
-    GEMINI_EMBEDDING_001 = ("embedding-001", 768)
-    GEMINI_EMBEDDING_002 = ("embedding-002", 1408)
-    GEMINI_TEXT_EMBEDDING_004 = ("text-embedding-004", 2048)
-    OPENAI_TEXT_EMBEDDING_3_SMALL = ("text-embedding-3-small", 1536)
-    OPENAI_TEXT_EMBEDDING_3_LARGE = ("text-embedding-3-large", 3072)
-    E5_MODEL = ("intfloat/e5-large-v2", 1024)
-
-    @property
-    def model_name(self) -> str:
-        return self.value[0]
-
-    @property
-    def embedding_size(self) -> int:
-        return self.value[1]
-    
 class LLMResponse:
+    """
+    Loads llm_config.yaml and instantiates LLM + embedding providers
+    based on env vars CURRENT_LLM and CURRENT_EMBEDDER. Both env vars
+    name a yaml key under `providers:`; the block's `protocol:` field
+    determines which Provider class handles it.
+
+    This lets a single deployment mix and match freely — e.g. chat via
+    a local vLLM Gemma, embeddings via a local Ollama mxbai — by adding
+    two provider blocks and setting the two env vars, with no code
+    change.
+    """
+
+    _PROTOCOL_TO_CLASS: dict[Protocol, type[LLMProvider]] = {
+        Protocol.GEMINI: GeminiProvider,
+        Protocol.OPENAI: OpenAIProvider,
+        Protocol.HUGGINGFACE: HuggingFaceModel,
+    }
+
     def __init__(self):
         self.config = None
         with open("app/llm_config.yaml", 'r') as f:
             self.config = yaml.safe_load(f)
-            
+
+    def _get_provider_block(self, provider_name: str) -> dict:
+        """Look up a provider block by yaml key; raise with a helpful list on miss."""
+        providers = self.config.get('providers') or {}
+        if provider_name not in providers:
+            raise ValueError(
+                f"Provider '{provider_name}' not found in llm_config.yaml. "
+                f"Known providers: {sorted(providers.keys())}. "
+                "Add a block under `providers:` or fix the CURRENT_LLM / "
+                "CURRENT_EMBEDDER env var."
+            )
+        return providers[provider_name]
+
+    def _instantiate(self, provider_name: str) -> LLMProvider:
+        """Build an LLMProvider from a config block, dispatching by `protocol:`.
+
+        Falls back to the block's `provider:` field for backward compat with
+        older configs that pre-date the protocol/name split.
+        """
+        block = self._get_provider_block(provider_name)
+        protocol_str = block.get('protocol') or block.get('provider')
+        if not protocol_str:
+            raise ValueError(
+                f"Provider '{provider_name}' has neither 'protocol' nor "
+                "'provider' set; can't decide which SDK to use."
+            )
+        try:
+            protocol = Protocol(protocol_str)
+        except ValueError:
+            raise ValueError(
+                f"Provider '{provider_name}' declares unknown protocol "
+                f"'{protocol_str}'. Known: {[p.value for p in Protocol]}."
+            )
+        return self._PROTOCOL_TO_CLASS[protocol](model_config=LLMModelConfig(block))
+
     @property
     def embedding_size(self) -> int:
-        """Return the embedding size based on the current embedding provider."""
-        provider = EmbeddingProvider(os.getenv("CURRENT_EMBEDDER", EmbeddingProvider.GEMINI.value)).value
-        if provider == EmbeddingProvider.GEMINI.value:
-            return EmbeddingModel.GEMINI_EMBEDDING_001.embedding_size
-        elif provider == EmbeddingProvider.OPENAI.value:
-            return EmbeddingModel.OPENAI_TEXT_EMBEDDING_3_SMALL.embedding_size
-        elif provider == EmbeddingProvider.HUGGINGFACE.value:
-            return EmbeddingModel.E5_MODEL.embedding_size
-        else:
-            raise ValueError(f"Unknown embedding provider: {provider}")
-        
+        """Vector dim expected from the current embedder.
+
+        Preferred source: `embedding_size:` on the provider block. Falls
+        back to a well-known-model lookup so pre-existing configs don't
+        need to be migrated all at once. Raises if neither resolves.
+        """
+        name = os.getenv("CURRENT_EMBEDDER", "gemini")
+        block = self._get_provider_block(name)
+        if 'embedding_size' in block and block['embedding_size'] is not None:
+            return int(block['embedding_size'])
+        embedding_model = block.get('embedding_model') or ''
+        if embedding_model in _EMBEDDING_MODEL_DIMS:
+            return _EMBEDDING_MODEL_DIMS[embedding_model]
+        raise ValueError(
+            f"Provider '{name}' has neither 'embedding_size' nor a "
+            f"recognized 'embedding_model' (got: {embedding_model!r}). "
+            "Add `embedding_size: <int>` to the block."
+        )
+
     @property
     def embedder(self) -> LLMProvider:
-        provider = EmbeddingProvider(os.getenv("CURRENT_EMBEDDER", EmbeddingProvider.GEMINI.value)).value
-        selected_config = LLMModelConfig(self.config['providers']["openai"])
-        if provider == EmbeddingProvider.GEMINI.value:
-            return GeminiProvider(model_config=selected_config)
-        elif provider == EmbeddingProvider.OPENAI.value:
-            return OpenAIProvider(model_config=selected_config)
-        elif provider == EmbeddingProvider.HUGGINGFACE.value:
-            return HuggingFaceModel(model_config=selected_config)
-    
+        return self._instantiate(os.getenv("CURRENT_EMBEDDER", "gemini"))
+
     @property
     def llm(self) -> LLMProvider:
-        provider = TextProvider(os.getenv("CURRENT_LLM", TextProvider.GEMINI.value)).value
-        selected_config = LLMModelConfig(self.config['providers'][provider])
-        if provider ==  TextProvider.GEMINI.value:
-            return GeminiProvider(model_config=selected_config)
-        elif provider ==  TextProvider.OPENAI.value:
-            return OpenAIProvider(model_config=selected_config)
+        return self._instantiate(os.getenv("CURRENT_LLM", "gemini"))
         
     async def get_embeddings(self, input):
         """ Get embeddings for input text. """

--- a/app/bioblend_server/server.py
+++ b/app/bioblend_server/server.py
@@ -124,10 +124,10 @@ async def get_galaxy_information_tool(
     
     except GalaxyConnectionError as e:
         logger.error(f"Failed to connect to Galaxy: {e}")
-        return f"Failed to connect to Galaxy: {e}"
+        return DefaultTextResponses(response=f"Failed to connect to Galaxy: {e}")
     except Exception as e:
         logger.error(f"Error in get_galaxy_information_tool: {e}", exc_info=True)
-        return f"An error occurred while fetching Galaxy information: {str(e)}"
+        return DefaultTextResponses(response=f"An error occurred while fetching Galaxy information: {e}")
     
 
 # ========================================================================================================== #

--- a/app/llm_config.py
+++ b/app/llm_config.py
@@ -11,7 +11,6 @@ class LLMModelConfig:
     def __init__(self, config_data: Dict[str, Any]) -> None:
         self.config_data = config_data
         self.model_name: str = config_data["model"]
-        self.provider: str = config_data["provider"]
         self.base_url: str = config_data["base_url"]
         self.embedding_model: str | None = config_data.get("embedding_model")
 

--- a/app/llm_config.yaml
+++ b/app/llm_config.yaml
@@ -38,27 +38,27 @@ providers:
     stream: true
     stop: null
 
-  # Example: chat via a self-hosted Gemma at a vLLM endpoint (OpenAI
-  # protocol). Uncomment + set CURRENT_LLM=local_llm to route chat here.
-  # local_llm:
-  #   protocol: openai
-  #   provider: openai
-  #   base_url: http://202.181.159.222:8002/v1
-  #   model: gemma4
-  #   temperature: 0.7
-  #   max_tokens: 8000
-  #   top_p: 1
-  #   stream: true
-  #   stop: null
+  # Chat via a self-hosted Gemma at a vLLM endpoint (OpenAI protocol).
+  # Selected when CURRENT_LLM=local_llm.
+  local_llm:
+    protocol: openai
+    provider: openai
+    base_url: http://202.181.159.222:8002/v1
+    model: gemma4
+    temperature: 0.7
+    max_tokens: 8000
+    top_p: 1
+    stream: true
+    stop: null
 
-  # Example: embeddings via a self-hosted Ollama endpoint (OpenAI protocol).
-  # Uncomment + set CURRENT_EMBEDDER=local_embed to route embeds here.
-  # local_embed:
-  #   protocol: openai
-  #   provider: openai
-  #   base_url: http://202.181.159.222:11434/v1
-  #   model: mxbai-embed-large:latest          # placeholder; only embedding_model matters
-  #   embedding_model: mxbai-embed-large:latest
-  #   embedding_size: 1024
+  # Embeddings via a self-hosted Ollama endpoint (OpenAI protocol).
+  # Selected when CURRENT_EMBEDDER=local_embed.
+  local_embed:
+    protocol: openai
+    provider: openai
+    base_url: http://202.181.159.222:11434/v1
+    model: mxbai-embed-large:latest
+    embedding_model: mxbai-embed-large:latest
+    embedding_size: 1024
 
 default_provider: gemini

--- a/app/llm_config.yaml
+++ b/app/llm_config.yaml
@@ -1,9 +1,24 @@
+# Each key under `providers:` is a free-form NAME (arbitrary string, chosen
+# by you) referenced by CURRENT_LLM and CURRENT_EMBEDDER env vars.
+#
+# `protocol:` tells the code which SDK to talk to the endpoint with — must
+# be one of gemini / openai / huggingface. That's how you can have a
+# "local_llm" block pointing at a vLLM server (which speaks the OpenAI
+# protocol) alongside the real openai cloud block.
+#
+# `embedding_size:` is the vector dim the model returns; used by the
+# Qdrant collection setup and the sanity-check on every embed call. If
+# omitted, a fallback lookup by embedding_model name kicks in for well-
+# known models (see _EMBEDDING_MODEL_DIMS in informer/utils.py).
+
 providers:
   gemini:
+    protocol: gemini
+    provider: gemini                 # kept for LLMModelConfig backward compat
     base_url: https://generativelanguage.googleapis.com/v1beta/models
     model: gemini-2.0-flash
-    embedding_model: embedding-001
-    provider: gemini
+    embedding_model: text-embedding-004
+    embedding_size: 768
     temperature: 0.7
     max_tokens: 1048576
     top_p: 1
@@ -11,14 +26,39 @@ providers:
     stop: null
 
   openai:
+    protocol: openai
+    provider: openai
     base_url: https://api.openai.com/v1
     model: gpt-4o-mini
     embedding_model: text-embedding-3-small
-    provider: openai
+    embedding_size: 1536
     temperature: 0.7
     max_tokens: 8000
     top_p: 1
     stream: true
     stop: null
+
+  # Example: chat via a self-hosted Gemma at a vLLM endpoint (OpenAI
+  # protocol). Uncomment + set CURRENT_LLM=local_llm to route chat here.
+  # local_llm:
+  #   protocol: openai
+  #   provider: openai
+  #   base_url: http://202.181.159.222:8002/v1
+  #   model: gemma4
+  #   temperature: 0.7
+  #   max_tokens: 8000
+  #   top_p: 1
+  #   stream: true
+  #   stop: null
+
+  # Example: embeddings via a self-hosted Ollama endpoint (OpenAI protocol).
+  # Uncomment + set CURRENT_EMBEDDER=local_embed to route embeds here.
+  # local_embed:
+  #   protocol: openai
+  #   provider: openai
+  #   base_url: http://202.181.159.222:11434/v1
+  #   model: mxbai-embed-large:latest          # placeholder; only embedding_model matters
+  #   embedding_model: mxbai-embed-large:latest
+  #   embedding_size: 1024
 
 default_provider: gemini

--- a/app/llm_config.yaml
+++ b/app/llm_config.yaml
@@ -14,7 +14,6 @@
 providers:
   gemini:
     protocol: gemini
-    provider: gemini                 # kept for LLMModelConfig backward compat
     base_url: https://generativelanguage.googleapis.com/v1beta/models
     model: gemini-2.0-flash
     embedding_model: text-embedding-004
@@ -27,7 +26,6 @@ providers:
 
   openai:
     protocol: openai
-    provider: openai
     base_url: https://api.openai.com/v1
     model: gpt-4o-mini
     embedding_model: text-embedding-3-small
@@ -42,7 +40,6 @@ providers:
   # Selected when CURRENT_LLM=local_llm.
   local_llm:
     protocol: openai
-    provider: openai
     base_url: http://202.181.159.222:8002/v1
     model: gemma4
     temperature: 0.7
@@ -55,7 +52,6 @@ providers:
   # Selected when CURRENT_EMBEDDER=local_embed.
   local_embed:
     protocol: openai
-    provider: openai
     base_url: http://202.181.159.222:11434/v1
     model: mxbai-embed-large:latest
     embedding_model: mxbai-embed-large:latest

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -233,7 +233,14 @@ class OpenAIProvider(LLMProvider):
         for r in results:
             embeddings.extend(r)
 
-        self.log.info("OpenAI embeddings generated.")
+        if not embeddings:
+            self.log.error(
+                "OpenAI embedding fetch produced no vectors — every batch "
+                "failed. Check base_url / api_key / model name for the "
+                "configured provider block."
+            )
+        else:
+            self.log.info(f"OpenAI embeddings generated ({len(embeddings)} vectors).")
         return embeddings
 
 # TODO: Fix abstraction here, since we are abstracting a configuration that the hugging face model wont be using.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - .env
     environment:
-      - OPENAI_API_KEY=${OPENAI_API}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - APP_PORT=${APP_PORT}
       - MCP_PORT=${MCP_PORT}
       - REDIS_PORT=${REDIS_PORT}

--- a/tests/MCP/test_server.py
+++ b/tests/MCP/test_server.py
@@ -187,8 +187,8 @@ class TestGetGalaxyInformationTool:
             query="test query", query_type="tool"
         )
 
-        assert "error" in result.lower()
-        assert "current user api-key is missing" in result.lower()
+        assert "error" in result.response.lower()
+        assert "current user api-key is missing" in result.response.lower()
         informer_test_log.info("TEST: test_missing_api_key PASSED")
 
     @pytest.mark.asyncio
@@ -205,8 +205,8 @@ class TestGetGalaxyInformationTool:
             query="test query", query_type="tool"
         )
 
-        assert "error" in result.lower()
-        assert "connection failed" in result.lower()
+        assert "error" in result.response.lower()
+        assert "connection failed" in result.response.lower()
         informer_test_log.info("TEST: test_galaxy_client_exception PASSED.")
 
 


### PR DESCRIPTION
## Summary

Refactors how mcp-xp resolves LLM/embedder providers so that self-hosted models can coexist alongside cloud openai and gemini blocks — the previous shape hardcoded a fixed `EmbeddingProvider` enum whose values doubled as SDK identifiers, which forced provider *identity* and *protocol* to be the same string.

## What changed

**Provider NAME vs protocol split** (`app/bioblend_server/informer/utils.py`, `app/llm_config.yaml`)
- Each yaml key under `providers:` is now a free-form NAME (e.g. `openai`, `local_llm`, `local_embed`).
- Each block declares `protocol: <gemini|openai|huggingface>` — the wire format the endpoint speaks. Multiple blocks can share the same protocol.
- `LLMResponse` reads the block by name via `CURRENT_LLM` / `CURRENT_EMBEDDER`, then dispatches to the matching SDK by `protocol:`. No more fixed enum.
- `embedding_size:` moves onto the yaml block; falls back to a well-known-model lookup (`_EMBEDDING_MODEL_DIMS`) if not declared.
- Removed the legacy `provider:` field entirely — it was only being stored on `LLMModelConfig` and never read.

**Local provider blocks activated**
- `local_llm` — self-hosted chat model behind a vLLM endpoint speaking the OpenAI protocol.
- `local_embed` — self-hosted embedding model behind an Ollama endpoint speaking the OpenAI protocol.
- Both were shipped commented-out; now live so setting `CURRENT_LLM=local_llm` / `CURRENT_EMBEDDER=local_embed` resolves without host-side yaml edits.

**Fixes surfaced along the way** (would have masked/broken the deploy without these):

1. `get_galaxy_information_tool` returned bare `str` on error but its declared type is `DefaultTextResponses`. FastMCP treats mismatched returns as `structured_content must be a dict`, hiding real exceptions behind a schema error. Now wraps error paths in `DefaultTextResponses(response=...)`.
2. `docker-compose.yml` was substituting `${OPENAI_API}` (undefined) into `OPENAI_API_KEY`, so the openai SDK inside the container always saw an empty key and refused to open connections — surfaced downstream as `Connection error` before requests reached the embedding endpoint. Renamed to `${OPENAI_API_KEY}`.
3. `OpenAIProvider.embedding_model` logged `"OpenAI embeddings generated."` unconditionally, even when every batch swallowed an error and returned `[]`. Now differentiates: empty result → ERROR with hint, non-empty → INFO with vector count.

## Verified end-to-end on staging

- AI Assistant reaches `get_galaxy_information_tool` via MCP handshake (previously blocked by the middleware bug fixed in #52).
- Embeddings resolve via `local_embed` → self-hosted endpoint returns vectors of the expected dim.
- Per-user Qdrant collection created fresh at the new dim; fuzzy + semantic search returns real workflows.
- Cross-encoder reranking + workflow metadata fetch + LLM synthesis all complete.

## Test plan

- [x] All 264 tests pass locally + in CI (see 30453868767).
- [x] `initialize` handshake handled correctly (regression check from PR #52 still holds).
- [x] With `CURRENT_EMBEDDER=local_embed` and a live embedding endpoint, `LLMResponse.embedder` resolves and produces vectors of `embedding_size` matching the block's declared dim.
- [x] With `CURRENT_LLM=local_llm` and a live chat endpoint, `LLMResponse.llm.get_response(...)` returns text.
- [x] Guarded tool error paths return `DefaultTextResponses` (schema-valid), not bare strings.