### PR TITLE
BackgroundIndexer: wire lifespan, timestamp-gate skip, robust batch embedding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .venv/
 .pytest_cache/
 .vscode/
+state/

--- a/app/bioblend_server/informer/global_rec.py
+++ b/app/bioblend_server/informer/global_rec.py
@@ -6,11 +6,13 @@ import logging
 from typing import Literal
 
 from app.bioblend_server.informer.manager import InformerManager
+from app.bioblend_server.informer.indexer_state import IndexerState
 from app.bioblend_server.informer.scrapers.tool_scraper import GalaxyToolScraper
 from app.bioblend_server.informer.scrapers.workflow_scraper import (
     GalaxyWorkflowScraper,
     WorkflowHubScraper,
 )
+from app.bioblend_server.informer.utils import InformerTTLs
 
 
 class GlobalRecommender:
@@ -21,6 +23,7 @@ class GlobalRecommender:
         self.tool_scraper = GalaxyToolScraper()
         self.workflow_scraper = GalaxyWorkflowScraper()
         self.hub_scraper = WorkflowHubScraper()
+        self.state = IndexerState()
 
     @classmethod
     async def create(cls):
@@ -28,12 +31,30 @@ class GlobalRecommender:
         self.manager = await InformerManager().create()
         return self
 
+    @staticmethod
+    def _collection_name(entity_type: Literal["tool", "workflow"]) -> str:
+        return f"generic_galaxy_{entity_type}"
+
+    def _skip_if_fresh(self, entity_type: Literal["tool", "workflow"]) -> bool:
+        name = self._collection_name(entity_type)
+        if self.state.is_fresh(name, InformerTTLs.LIFESPAN.value):
+            last = self.state.get_last_indexed(name)
+            self.log.info(
+                f"Skipping scrape of {name}; last indexed at {last.isoformat()}."
+            )
+            return True
+        return False
+
     async def store_scraped_tools(self):
+        if self._skip_if_fresh("tool"):
+            return
         scraped_tools = await self.tool_scraper.scrape_tool()
         await self.tool_scraper.close()
         await self.store_to_collection(scraped_tools, "tool")
 
     async def store_scraped_workflows(self):
+        if self._skip_if_fresh("workflow"):
+            return
         github_workflows = await self.workflow_scraper.scrape_workflows()
         hub_workflows = await self.hub_scraper.scrape_workflows()
 
@@ -66,9 +87,15 @@ class GlobalRecommender:
     async def store_to_collection(
         self, scraped_data: list[dict], entity_type: Literal["tool", "workflow"]
     ):
-        collection_name = f"generic_galaxy_{entity_type}"
+        collection_name = self._collection_name(entity_type)
         self.log.info(f"Storing scraped galaxy data to Qdrant.")
-        await self.manager.embed_and_store_entities(
+        result = await self.manager.embed_and_store_entities(
             entities=scraped_data, collection_name=collection_name
         )
+        if result is None:
+            self.log.error(
+                f"Aborting freshness update for {collection_name}: embed_and_store_entities failed."
+            )
+            return
+        self.state.mark_indexed(collection_name)
         self.log.info(f"content embedded and stored in {collection_name} succefully.")

--- a/app/bioblend_server/informer/indexer_state.py
+++ b/app/bioblend_server/informer/indexer_state.py
@@ -1,0 +1,87 @@
+"""Persistent last-indexed timestamps for BackgroundIndexer collections.
+
+Prevents the "re-scrape everything on every container restart" behavior
+that happens when there's no memory of prior indexing runs.
+
+Persistence relies on the enclosing directory being bind-mounted from
+the host. See docker-compose.yml volume `./state:/app/state`. Without
+the mount the file still works inside the container filesystem, but it
+gets wiped on rebuild — degrading gracefully to the old always-reindex
+behavior instead of failing loudly.
+"""
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+DEFAULT_STATE_PATH = os.environ.get(
+    "INDEXER_STATE_PATH", "/app/state/last_indexed.json"
+)
+
+
+class IndexerState:
+    """Reads/writes a JSON map of {collection_name: ISO8601 timestamp}."""
+
+    def __init__(self, path: str = DEFAULT_STATE_PATH):
+        self.path = Path(path)
+        self.log = logging.getLogger(self.__class__.__name__)
+        self._ensure_dir()
+
+    def _ensure_dir(self):
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            self.log.warning(
+                f"Could not create indexer state directory {self.path.parent}: {e}"
+            )
+
+    def _read(self) -> dict[str, str]:
+        if not self.path.exists():
+            return {}
+        try:
+            with self.path.open("r") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError) as e:
+            self.log.warning(f"Failed to read indexer state at {self.path}: {e}")
+            return {}
+
+    def _write(self, data: dict[str, str]):
+        try:
+            with NamedTemporaryFile(
+                "w",
+                dir=self.path.parent,
+                delete=False,
+                prefix=".tmp-",
+                suffix=".json",
+            ) as tmp:
+                json.dump(data, tmp, indent=2, sort_keys=True)
+                tmp_path = Path(tmp.name)
+            tmp_path.replace(self.path)
+        except OSError as e:
+            self.log.warning(f"Failed to write indexer state at {self.path}: {e}")
+
+    def get_last_indexed(self, collection: str) -> datetime | None:
+        raw = self._read().get(collection)
+        if not raw:
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            self.log.warning(f"Malformed timestamp for {collection!r}: {raw!r}")
+            return None
+
+    def mark_indexed(self, collection: str):
+        data = self._read()
+        data[collection] = datetime.now(timezone.utc).isoformat()
+        self._write(data)
+
+    def is_fresh(self, collection: str, lifespan_seconds: int) -> bool:
+        ts = self.get_last_indexed(collection)
+        if ts is None:
+            return False
+        age = (datetime.now(timezone.utc) - ts).total_seconds()
+        return age < lifespan_seconds

--- a/app/bioblend_server/informer/manager.py
+++ b/app/bioblend_server/informer/manager.py
@@ -80,10 +80,22 @@ class InformerManager:
             self.logger.error("Invalid data format. Expected a list of dictionaries.")
             raise ValueError("Input data must be a list of dictionaries.")
 
+    # Cap per-entity content before embedding. mxbai-embed-large tops out at
+    # ~512 tokens; long Galaxy workflow descriptions overflow that and
+    # ollama's OpenAI adapter 400s the entire batch. ~1800 chars is a safe
+    # English-prose approximation of 512 tokens with headroom.
+    _MAX_EMBED_CHARS = 1800
+
     async def _generate_embeddings(self, df: pd.DataFrame) -> pd.DataFrame:
         try:
             self.logger.info("Generating vector embeddings for entity content.")
-            df['dense'] = await self.embedder.get_embeddings(df['content'].tolist())
+            contents = [
+                (s[: self._MAX_EMBED_CHARS - 1] + "\u2026")
+                if isinstance(s, str) and len(s) > self._MAX_EMBED_CHARS
+                else s
+                for s in df['content'].tolist()
+            ]
+            df['dense'] = await self.embedder.get_embeddings(contents)
             self.logger.info(f"Embeddings generated successfully with size {self.embedder.embedding_size}.")
             return df
         except Exception as e:

--- a/app/bioblend_server/informer/manager.py
+++ b/app/bioblend_server/informer/manager.py
@@ -81,10 +81,12 @@ class InformerManager:
             raise ValueError("Input data must be a list of dictionaries.")
 
     # Cap per-entity content before embedding. mxbai-embed-large tops out at
-    # ~512 tokens; long Galaxy workflow descriptions overflow that and
-    # ollama's OpenAI adapter 400s the entire batch. ~1800 chars is a safe
-    # English-prose approximation of 512 tokens with headroom.
-    _MAX_EMBED_CHARS = 1800
+    # ~512 tokens; Galaxy tool XML and JSON-heavy content packs many tokens
+    # per char, so a conservative bound is safer than the English-prose
+    # rule-of-thumb.  Anything longer gets truncated with a "…" suffix; the
+    # per-item retry path in OpenAIProvider catches whatever still slips
+    # through.
+    _MAX_EMBED_CHARS = 1200
 
     async def _generate_embeddings(self, df: pd.DataFrame) -> pd.DataFrame:
         try:
@@ -95,8 +97,26 @@ class InformerManager:
                 else s
                 for s in df['content'].tolist()
             ]
-            df['dense'] = await self.embedder.get_embeddings(contents)
-            self.logger.info(f"Embeddings generated successfully with size {self.embedder.embedding_size}.")
+            raw = await self.embedder.get_embeddings(contents)
+            if len(raw) != len(df):
+                raise ValueError(
+                    f"Embedder returned {len(raw)} vectors for {len(df)} inputs "
+                    "— input/output length mismatch, cannot align to dataframe."
+                )
+            # Drop rows whose embedding failed (per-item retry returned None).
+            keep_mask = [v is not None for v in raw]
+            dropped = len(keep_mask) - sum(keep_mask)
+            if dropped:
+                self.logger.warning(
+                    f"Dropping {dropped} entities that failed to embed "
+                    "(likely oversized content that survived truncation)."
+                )
+            df = df.loc[keep_mask].reset_index(drop=True)
+            df['dense'] = [v for v in raw if v is not None]
+            self.logger.info(
+                f"Embeddings generated successfully with size {self.embedder.embedding_size} "
+                f"({len(df)} rows kept)."
+            )
             return df
         except Exception as e:
             self.logger.error(f"Error generating dense embeddings: {e}")

--- a/app/bioblend_server/informer/manager.py
+++ b/app/bioblend_server/informer/manager.py
@@ -13,6 +13,7 @@ from qdrant_client.models import Filter, FieldCondition, MatchText, PointStruct
 
 from app.log_setup import configure_logging
 from app.bioblend_server.informer.utils import LLMResponse
+from app.llm_provider import EMBED_MAX_INPUT_CHARS
 
 class InformerManager:
     """
@@ -80,20 +81,12 @@ class InformerManager:
             self.logger.error("Invalid data format. Expected a list of dictionaries.")
             raise ValueError("Input data must be a list of dictionaries.")
 
-    # Cap per-entity content before embedding. mxbai-embed-large tops out at
-    # ~512 tokens; Galaxy tool XML and JSON-heavy content packs many tokens
-    # per char, so a conservative bound is safer than the English-prose
-    # rule-of-thumb.  Anything longer gets truncated with a "…" suffix; the
-    # per-item retry path in OpenAIProvider catches whatever still slips
-    # through.
-    _MAX_EMBED_CHARS = 1200
-
     async def _generate_embeddings(self, df: pd.DataFrame) -> pd.DataFrame:
         try:
             self.logger.info("Generating vector embeddings for entity content.")
             contents = [
-                (s[: self._MAX_EMBED_CHARS - 1] + "\u2026")
-                if isinstance(s, str) and len(s) > self._MAX_EMBED_CHARS
+                (s[: EMBED_MAX_INPUT_CHARS - 1] + "…")
+                if isinstance(s, str) and len(s) > EMBED_MAX_INPUT_CHARS
                 else s
                 for s in df['content'].tolist()
             ]

--- a/app/bioblend_server/informer/utils.py
+++ b/app/bioblend_server/informer/utils.py
@@ -154,17 +154,26 @@ class LLMResponse:
         return self._instantiate(os.getenv("CURRENT_LLM", "gemini"))
         
     async def get_embeddings(self, input):
-        """ Get embeddings for input text. """
-        
+        """Get embeddings for input text.
+
+        Returns one embedding per input, preserving per-input alignment.
+        Entries whose upstream provider call failed (e.g. context-length
+        rejection during the per-item retry path) come back as ``None`` so
+        the caller can drop the corresponding row from its dataframe. The
+        embedding-size sanity check runs only against successful entries.
+        """
         raw = await self.embedder.embedding_model(input)
-        embed= np.array(raw)
-        if embed.shape[-1] != self.embedding_size:
-            raise ValueError(f"Expected embedding dimension {self.embedding_size}, got {embed.shape[-1]}")
-        embeddings = embed.reshape(-1, self.embedding_size)
+        valid = [v for v in raw if v is not None]
+        if valid:
+            embed = np.array(valid)
+            if embed.shape[-1] != self.embedding_size:
+                raise ValueError(
+                    f"Expected embedding dimension {self.embedding_size}, "
+                    f"got {embed.shape[-1]}"
+                )
         if len(input) == 1:
-            return embeddings.tolist()[0]
-        else:
-            return embeddings.tolist()
+            return raw[0]
+        return raw
     
     async def get_response(self, message):
         """Get response from LLM."""

--- a/app/bioblend_server/server.py
+++ b/app/bioblend_server/server.py
@@ -72,9 +72,10 @@ bioblend_app = FastMCP(
                             Provide information on Galaxy tools, datasets, workflows, and invocations.
                             Explain failures and recommend fixes.
                             Import recommended workflows when requested.
-                            
+
                             """,
-                    middleware=[JWTGalaxyKeyMiddleware()]
+                    middleware=[JWTGalaxyKeyMiddleware()],
+                    lifespan=mcp_galaxy_lifespan,
                     )
 
 

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -216,9 +216,32 @@ class OpenAIProvider(LLMProvider):
                     )
                     return [e.embedding for e in result.data]
                 except Exception as e:
-                    self.log.error(f"OpenAI Embedding error: {e}")
-                    await asyncio.sleep(sleep_time)  # backoff before retry
-                    return []
+                    # A whole batch of 100 fails if even one item is oversize —
+                    # ollama's OpenAI adapter rejects the entire request.  Fall
+                    # back to per-item embedding so we lose only the offenders,
+                    # not the whole batch.  Failed items get None sentinels so
+                    # the caller can drop them (rather than silently
+                    # length-mismatching the df).
+                    self.log.warning(
+                        f"OpenAI batch of {len(batch_segment)} failed, retrying "
+                        f"per-item to isolate offender(s): {e}"
+                    )
+                    await asyncio.sleep(sleep_time)
+                    individual: List[List[float] | None] = []
+                    for item in batch_segment:
+                        try:
+                            r = await self.client.embeddings.create(
+                                model=embedding_model,
+                                input=[item],
+                            )
+                            individual.append(r.data[0].embedding)
+                        except Exception as e2:
+                            self.log.error(
+                                f"OpenAI single-item embed failed "
+                                f"(item len={len(item) if isinstance(item, str) else 'n/a'}): {e2}"
+                            )
+                            individual.append(None)
+                    return individual
 
         # Create all batch tasks
         tasks = [

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -194,12 +194,10 @@ class OpenAIProvider(LLMProvider):
         - Returns a flat list of embeddings
         - Async native calls
         """
-        
 
         embeddings: List[List[float]] = []
         batch_size = 100
         sleep_time = 2  # Time to wait before retrying after an error
-
 
         embedding_model = self.config.config_data.get("embedding_model")
         if not embedding_model:
@@ -207,14 +205,26 @@ class OpenAIProvider(LLMProvider):
 
         sem = asyncio.Semaphore(5)  # limit concurrency to avoid rate limit spikes
 
-        async def fetch_batch(batch_segment):
+        total = len(batch)
+        n_batches = (total + batch_size - 1) // batch_size
+        # Progress counter shared across concurrent fetch_batch coroutines. Wrapped
+        # in a list so the closure can mutate it under the lock; asyncio's
+        # single-threaded semantics still make the read+increment safe.
+        progress = [0]
+        progress_lock = asyncio.Lock()
+
+        self.log.info(
+            f"Embedding {total} items across {n_batches} batches of {batch_size}."
+        )
+
+        async def fetch_batch(batch_segment, batch_idx):
             async with sem:
                 try:
                     result = await self.client.embeddings.create(
                         model=embedding_model,
                         input=batch_segment,
                     )
-                    return [e.embedding for e in result.data]
+                    out = [e.embedding for e in result.data]
                 except Exception as e:
                     # A whole batch of 100 fails if even one item is oversize —
                     # ollama's OpenAI adapter rejects the entire request.  Fall
@@ -223,11 +233,13 @@ class OpenAIProvider(LLMProvider):
                     # the caller can drop them (rather than silently
                     # length-mismatching the df).
                     self.log.warning(
-                        f"OpenAI batch of {len(batch_segment)} failed, retrying "
-                        f"per-item to isolate offender(s): {e}"
+                        f"[batch {batch_idx}/{n_batches}] failed "
+                        f"({len(batch_segment)} items), retrying per-item to "
+                        f"isolate offender(s): {e}"
                     )
                     await asyncio.sleep(sleep_time)
                     individual: List[List[float] | None] = []
+                    fail_count = 0
                     for item in batch_segment:
                         try:
                             r = await self.client.embeddings.create(
@@ -236,16 +248,31 @@ class OpenAIProvider(LLMProvider):
                             )
                             individual.append(r.data[0].embedding)
                         except Exception as e2:
+                            fail_count += 1
                             self.log.error(
-                                f"OpenAI single-item embed failed "
+                                f"[batch {batch_idx}/{n_batches}] single-item "
+                                f"embed failed "
                                 f"(item len={len(item) if isinstance(item, str) else 'n/a'}): {e2}"
                             )
                             individual.append(None)
-                    return individual
+                    self.log.info(
+                        f"[batch {batch_idx}/{n_batches}] per-item retry done "
+                        f"({len(batch_segment) - fail_count}/{len(batch_segment)} succeeded)."
+                    )
+                    out = individual
+
+                async with progress_lock:
+                    progress[0] += 1
+                    # Log every batch for small runs, every 10 for large runs.
+                    if n_batches <= 20 or progress[0] % 10 == 0 or progress[0] == n_batches:
+                        self.log.info(
+                            f"Embedding progress: {progress[0]}/{n_batches} batches complete."
+                        )
+                return out
 
         # Create all batch tasks
         tasks = [
-            fetch_batch(batch[i:i + batch_size])
+            fetch_batch(batch[i:i + batch_size], (i // batch_size) + 1)
             for i in range(0, len(batch), batch_size)
         ]
 
@@ -263,7 +290,10 @@ class OpenAIProvider(LLMProvider):
                 "configured provider block."
             )
         else:
-            self.log.info(f"OpenAI embeddings generated ({len(embeddings)} vectors).")
+            self.log.info(
+                f"OpenAI embeddings generated ({len(embeddings)} vectors from "
+                f"{n_batches} batches)."
+            )
         return embeddings
 
 # TODO: Fix abstraction here, since we are abstracting a configuration that the hugging face model wont be using.

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -21,6 +21,48 @@ from app.llm_config import LLMModelConfig
 from app.config import GEMINI_API_KEY, OPENAI_API_KEY
 from app.utils import _extract_json_from_llm_response
 
+
+# --- Embedding tuning constants ---
+#
+# All empirically chosen for the local embedder path
+# (mxbai-embed-large via ollama's OpenAI-compat endpoint).  Swapping to
+# a cloud embedder with more context and higher concurrency ceilings
+# would justify revisiting these.
+
+# How many items per single batch request to the embedding endpoint.
+# Ollama serializes embeddings per-model internally, so raising this
+# rarely helps throughput; keeping it modest also limits the blast
+# radius when a batch contains an over-limit item and the server 400s
+# the whole request.
+EMBED_BATCH_SIZE = 100
+
+# Number of batch requests allowed in-flight simultaneously.
+# Single-GPU ollama tends to serialize anyway; too high risks
+# server-side rate limiting on cloud providers.
+EMBED_MAX_CONCURRENCY = 5
+
+# Seconds to sleep before falling back to per-item retry after a batch
+# request fails, giving transient network errors a moment to clear.
+EMBED_RETRY_SLEEP_S = 2
+
+# Emit a progress log line every N batches once the total exceeds
+# EMBED_VERBOSE_BATCH_THRESHOLD.
+EMBED_PROGRESS_LOG_INTERVAL = 10
+
+# For runs with this-many-or-fewer batches, log every batch (chatty but
+# useful on small runs).  Above this, throttle to
+# EMBED_PROGRESS_LOG_INTERVAL.
+EMBED_VERBOSE_BATCH_THRESHOLD = 20
+
+# Cap on per-item content sent to the embedder.  mxbai-embed-large tops
+# out at ~512 tokens; Galaxy tool XML and JSON-heavy content packs more
+# tokens per char than the English-prose rule of thumb, so a conservative
+# bound is safer.  Anything longer gets truncated with a "…" suffix; the
+# per-item retry path in OpenAIProvider catches whatever still slips
+# through.  Empirically: 1200 dropped 2 items out of 16,811.
+EMBED_MAX_INPUT_CHARS = 1200
+
+
 # Abstract Provider Base Class
 class LLMProvider(ABC):
     def __init__(self, model_config: LLMModelConfig) -> None:
@@ -196,14 +238,14 @@ class OpenAIProvider(LLMProvider):
         """
 
         embeddings: List[List[float]] = []
-        batch_size = 100
-        sleep_time = 2  # Time to wait before retrying after an error
+        batch_size = EMBED_BATCH_SIZE
+        sleep_time = EMBED_RETRY_SLEEP_S
 
         embedding_model = self.config.config_data.get("embedding_model")
         if not embedding_model:
             raise ValueError("Missing 'embedding_model' in config_data")
 
-        sem = asyncio.Semaphore(5)  # limit concurrency to avoid rate limit spikes
+        sem = asyncio.Semaphore(EMBED_MAX_CONCURRENCY)
 
         total = len(batch)
         n_batches = (total + batch_size - 1) // batch_size
@@ -263,8 +305,12 @@ class OpenAIProvider(LLMProvider):
 
                 async with progress_lock:
                     progress[0] += 1
-                    # Log every batch for small runs, every 10 for large runs.
-                    if n_batches <= 20 or progress[0] % 10 == 0 or progress[0] == n_batches:
+                    # Log every batch for small runs, throttled on large ones.
+                    if (
+                        n_batches <= EMBED_VERBOSE_BATCH_THRESHOLD
+                        or progress[0] % EMBED_PROGRESS_LOG_INTERVAL == 0
+                        or progress[0] == n_batches
+                    ):
                         self.log.info(
                             f"Embedding progress: {progress[0]}/{n_batches} batches complete."
                         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - mongo
     volumes:
       - ./logs:/app/logs
+      - ./state:/app/state
     networks:
       - default
       - rejuve-network

--- a/docs/embed-timings.md
+++ b/docs/embed-timings.md
@@ -1,0 +1,159 @@
+# Embedding throughput observations
+
+Notes on how long the `BackgroundIndexer`'s per-cycle embed loop actually
+takes against a self-hosted mxbai-embed-large on ollama. Recorded from live hetzner staging runs on
+2026-08-05 while chasing the wrong-dim `generic_galaxy_workflow` bug.
+
+## Setup at time of measurement
+
+- Embedder: `mxbai-embed-large:latest` via ollama's OpenAI-compat endpoint
+- Client: `OpenAIProvider` at concurrency 5 (`asyncio.Semaphore(5)`),
+  batch size 100
+- Content truncated to 1200 chars before embedding
+- Two batches (116, 117) had one item each that still overflowed context
+  at 1200 chars → per-item retry, one item dropped per batch
+
+## Workflows collection — 548 items, 6 batches
+
+| stage | time | delta |
+|-------|------|-------|
+| `Storing scraped galaxy data` | 11:27:09 | — |
+| `Generating vector embeddings` | 11:27:09 | 0s |
+| `OpenAI embeddings generated (548 vectors)` | 11:29:11 | 2m 2s |
+| collection delete + create + upsert | 11:29:12 | ~1s |
+
+**Total: ~2 minutes for 548 workflows, all six batches happy path.**
+
+## Tools collection — 16,811 items, 169 batches (first run)
+
+Cold start on ollama. Progress logs every 10 batches.
+
+| checkpoint | time | since start | delta from prev | per-10-batches |
+|-----------|------|-------------|-----------------|----------------|
+| embed start | 11:49:54 | 0m | — | — |
+| 10/169 | 11:57:59 | 8m 5s | 8m 5s | 8m 5s |
+| 20/169 | 12:05:00 | 15m 6s | 7m 1s | 7m 1s |
+| 30/169 | 12:08:24 | 18m 30s | 3m 24s | 3m 24s |
+| 40/169 | 12:10:59 | 21m 5s | 2m 35s | 2m 35s |
+| 50/169 | 12:14:54 | 25m 0s | 3m 55s | 3m 55s |
+| 60/169 | 12:17:14 | 27m 20s | 2m 20s | 2m 20s |
+| 110/169 | 12:34:28 | 44m 34s | ~17m 14s over 50 | ~3m 27s |
+| batch 116 failed | 12:38:30 | 48m 36s | — | per-item retry |
+| batch 117 failed | 12:38:32 | 48m 38s | — | per-item retry |
+| 120/169 | 12:39:10 | 49m 16s | 4m 42s | 4m 42s |
+| 130/169 | 12:44:11 | 54m 17s | 5m 1s | 5m 1s |
+| 140/169 | 12:47:33 | 57m 39s | 3m 22s | 3m 22s |
+| 150/169 | 12:52:29 | 62m 35s | 4m 56s | 4m 56s |
+| 160/169 | 12:56:09 | 66m 15s | 3m 40s | 3m 40s |
+| batch 117 single-item fail (item len=1200) | 12:55:02 | 65m 8s | — | one item dropped |
+| batch 116 single-item fail (item len=1200) | 13:04:17 | 74m 23s | — | one item dropped |
+| batch 116 per-item retry done (99/100) | 13:04:40 | 74m 46s | — | — |
+| batch 117 per-item retry done (99/100) | 13:04:42 | 74m 48s | — | — |
+| 169/169 (complete) | 13:04:42 | 74m 48s | — | — |
+| `OpenAI embeddings generated (16811 vectors from 169 batches)` | 13:04:42 | 74m 48s | — | — |
+
+**Total: ~1h 15m for 16,811 tools in this run, dropping 2 items that were
+too dense for mxbai's context even at 1200 chars.**
+
+Note: this run *rolled back* at the numpy conversion step in
+`utils.py::get_embeddings` because `np.array(raw)` couldn't handle
+`None` sentinels from the two dropped items. Fixed in `1d4963e`. No
+points were written to Qdrant on this run.
+
+## Tools collection — 16,811 items, 169 batches (second run, after fix)
+
+Ollama warm from the first run.  Same two batches (116, 117) hit the same
+two 1200-char items and dropped them via per-item retry.
+
+| checkpoint | time | since embed start | delta from prev |
+|-----------|------|-------------------|-----------------|
+| scrape start | 13:19:49 | (pre-embed) | — |
+| embed start | 13:21:26 | 0m | 1m 37s scrape |
+| 10/169 | 13:28:18 | 6m 52s | 6m 52s |
+| 20/169 | 13:31:22 | 9m 56s | 3m 4s |
+| 30/169 | 13:34:44 | 13m 18s | 3m 22s |
+| 40/169 | 13:37:19 | 15m 53s | 2m 35s |
+| 50/169 | 13:40:45 | 19m 19s | 3m 26s |
+| 60/169 | 13:43:05 | 21m 39s | 2m 20s |
+| 70/169 | 13:47:16 | 25m 50s | 4m 11s |
+| 80/169 | 13:50:43 | 29m 17s | 3m 27s |
+| 90/169 | 13:54:46 | 33m 20s | 4m 3s |
+| 100/169 | 14:02:12 | 40m 46s | 7m 26s |
+| 110/169 | 14:07:15 | 45m 49s | 5m 3s |
+| batch 116 failed → retry | 14:12:14 | 50m 48s | — |
+| batch 117 failed → retry | 14:12:16 | 50m 50s | — |
+| 120/169 | 14:12:53 | 51m 27s | 5m 38s |
+| 130/169 | 14:18:08 | 56m 42s | 5m 15s |
+| 140/169 | 14:21:20 | 59m 54s | 3m 12s |
+| 150/169 | 14:29:35 | 68m 9s | 8m 15s |
+| batch 117 single-item fail (len=1200) | 14:37:36 | 76m 10s | — |
+| 160/169 | 14:38:41 | 77m 15s | 9m 6s |
+| batch 116 single-item fail (len=1200) | 14:41:16 | 79m 50s | — |
+| batch 116 per-item retry done (99/100) | 14:41:37 | 80m 11s | — |
+| batch 117 per-item retry done (99/100) | 14:41:38 | 80m 12s | — |
+| 169/169 (complete) | 14:41:38 | 80m 12s | — |
+| dim check + drop 2 Nones + upsert | 14:41:47 | 80m 21s | ~9s to write 16,809 points |
+| `content embedded and stored ... succefully` | 14:41:47 | 80m 21s | — |
+| `Cycle complete. Sleeping.` | 14:41:47 | 80m 21s | — |
+
+**Total: ~1h 20m for the second run — slightly *slower* than the first
+(1h 15m).** The warm-start advantage (first 10 batches were 6m 52s vs
+8m 5s) was offset by higher variance in the middle/late batches — the
+90→100 delta was 7m 26s, the 140→150 delta was 8m 15s, and 150→160
+took 9m 6s.  Two suspected causes:
+
+1. Concurrent user traffic on the same mcp-app pod (real AI-Assistant
+   queries were coming in around 12:52-13:04 and again mid-run), sharing
+   the ollama connection budget.
+2. Batch 117's oversized item was retried at 14:37:36 while other
+   batches were still queued behind it — the sequential per-item path
+   blocks the semaphore slot for the ~40s the retry loop takes.
+
+## Comparison
+
+| run | start | end | wall | notes |
+|-----|-------|-----|------|-------|
+| 1 (cold, aborted) | 11:49:54 | 13:04:42 | 74m 48s | rolled back on np.array None-mismatch |
+| 2 (warm, success) | 13:21:26 | 14:41:47 | 80m 21s | 16,809 rows written; both timestamps saved |
+
+Interesting that the "warm" run wasn't materially faster than cold —
+suggests the concurrency ceiling really is on the ollama-server side
+and cache priming on the model itself doesn't help throughput much
+once the model is loaded.  What *does* speed up subsequent restarts is
+the freshness gate itself: run 3 (any restart within the next 7 days)
+will complete in ~1s because both timestamps skip.
+
+## Upsert phase (Qdrant, not ollama)
+
+Once embeddings exist, writing 16,809 vectors to Qdrant took **~7
+seconds total** (35 upsert calls of 500 points each, ~0.2s per call).
+Bottleneck really is 100% on the embedding side, not storage.
+
+## Trends and observations
+
+- **Cold-start penalty is real.** The first 20 batches took ~15 minutes
+  (7m 30s per 10); after warm-up the rate settled at ~3-4 min per 10
+  batches — roughly 2× faster.
+- **Concurrency ceiling is ollama, not the client.** With
+  `Semaphore(5)` the effective throughput is ~2 embeddings/sec sustained.
+  Suggests ollama serializes embeddings per model internally regardless
+  of batch size.
+- **Per-item retry cost is significant when it fires.** A batch that
+  falls back to per-item mode takes ~50s (100 sequential single-item
+  calls at ~0.5s each) vs. ~2s for a happy batch of 100. On a run with
+  many oversized items this is the dominant cost.
+- **1200-char truncation is 99% effective.** Only 2 items out of 16,811
+  overflowed even at that cap — likely tools with dense XML/JSON
+  content packing >0.4 tokens per char. Tightening to 800 chars would
+  cover the tail, at the price of losing more context from every item.
+- **The tools scrape itself is fast** (~1.5 min to fetch 16,811 tool
+  metadata blobs from `usegalaxy.eu`). The bottleneck is the embed, not
+  the scrape.
+
+## Implications for the freshness gate
+
+- Full cold cycle: ~1h 20m (workflows + tools).
+- Full warm cycle: probably ~50m (mostly tools).
+- Skip-both cycle (both timestamps present, both < 7 days old): ~1s.
+- The 7-day `LIFESPAN` in `InformerTTLs` is a good default given the
+  cold cost — probably don't want to run this more than weekly.

--- a/tests/MCP/test_indexer_state.py
+++ b/tests/MCP/test_indexer_state.py
@@ -1,0 +1,70 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.bioblend_server.informer.indexer_state import IndexerState
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "last_indexed.json"
+
+
+@pytest.fixture
+def state(state_path: Path) -> IndexerState:
+    return IndexerState(path=str(state_path))
+
+
+class TestIndexerState:
+    def test_missing_file_returns_none(self, state):
+        assert state.get_last_indexed("generic_galaxy_tool") is None
+
+    def test_missing_file_is_never_fresh(self, state):
+        assert state.is_fresh("generic_galaxy_tool", lifespan_seconds=60) is False
+
+    def test_mark_and_read_roundtrip(self, state):
+        state.mark_indexed("generic_galaxy_tool")
+        ts = state.get_last_indexed("generic_galaxy_tool")
+        assert ts is not None
+        assert ts.tzinfo is not None  # timezone-aware
+
+    def test_fresh_within_lifespan(self, state):
+        state.mark_indexed("generic_galaxy_tool")
+        assert state.is_fresh("generic_galaxy_tool", lifespan_seconds=60) is True
+
+    def test_stale_past_lifespan(self, state, state_path):
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+        state_path.write_text(json.dumps({"generic_galaxy_tool": old_ts}))
+        assert state.is_fresh("generic_galaxy_tool", lifespan_seconds=7 * 86400) is False
+
+    def test_two_collections_tracked_independently(self, state):
+        state.mark_indexed("generic_galaxy_tool")
+        assert state.get_last_indexed("generic_galaxy_workflow") is None
+        state.mark_indexed("generic_galaxy_workflow")
+        assert state.get_last_indexed("generic_galaxy_workflow") is not None
+        assert state.get_last_indexed("generic_galaxy_tool") is not None
+
+    def test_malformed_json_treated_as_empty(self, state, state_path, caplog):
+        state_path.write_text("this is not json")
+        with caplog.at_level(logging.WARNING):
+            assert state.get_last_indexed("generic_galaxy_tool") is None
+        assert "Failed to read indexer state" in caplog.text
+
+    def test_malformed_timestamp_treated_as_absent(self, state, state_path, caplog):
+        state_path.write_text(json.dumps({"generic_galaxy_tool": "not-a-timestamp"}))
+        with caplog.at_level(logging.WARNING):
+            assert state.get_last_indexed("generic_galaxy_tool") is None
+        assert "Malformed timestamp" in caplog.text
+
+    def test_non_dict_json_treated_as_empty(self, state, state_path):
+        state_path.write_text(json.dumps(["not", "a", "dict"]))
+        assert state.get_last_indexed("generic_galaxy_tool") is None
+
+    def test_write_is_atomic(self, state, state_path):
+        state.mark_indexed("generic_galaxy_tool")
+        # After a write, no leftover .tmp-* files hang around next to the state file
+        siblings = list(state_path.parent.glob(".tmp-*"))
+        assert siblings == []

--- a/tests/MCP/test_llm_provider.py
+++ b/tests/MCP/test_llm_provider.py
@@ -375,13 +375,20 @@ class TestOpenAIProvider:
 
     @pytest.mark.asyncio
     async def test_openai_embedding_model_error_retry(self, openai_config):
-        """Test embedding generation with error and retry."""
+        """Batch failure falls back to per-item embedding.
+
+        When the initial batch call raises, the provider now retries each item
+        one at a time so a single oversized entity doesn't nuke the whole
+        batch. This test simulates that: first call (batch) raises, subsequent
+        per-item calls succeed, and the final result contains one embedding
+        per input.
+        """
         with patch("app.llm_provider.AsyncOpenAI") as mock_client_class:
             mock_client = AsyncMock()
             mock_client_class.return_value = mock_client
-            
+
             batch = ["text1", "text2"]
-            
+
             call_count = 0
             async def mock_create(**kwargs):
                 nonlocal call_count
@@ -394,17 +401,18 @@ class TestOpenAIProvider:
                     MagicMock(embedding=[0.3, 0.4])
                 ]
                 return mock_response
-            
+
             mock_client.embeddings.create = mock_create
-            
+
             provider = OpenAIProvider(openai_config)
-            
+
             with patch("asyncio.sleep", new_callable=AsyncMock):
                 result = await provider.embedding_model(batch)
-                
-                # First call fails and returns empty list for that batch
-                # The error is caught and logged, but doesn't retry automatically
-                assert len(result) == 0
+
+                # 1 initial batch call (fails) + 2 per-item retry calls (succeed).
+                assert call_count == 3
+                # Every input recovered via per-item retry.
+                assert len(result) == 2
 
     @pytest.mark.asyncio
     async def test_openai_embedding_model_missing_config(self, openai_config):


### PR DESCRIPTION
## Summary

Three related fixes to the global recommender's `BackgroundIndexer`, plus supporting robustness for the embedding path so long index cycles don't lose all their work on a single bad item.

## What the branch does

**1. Wires `mcp_galaxy_lifespan` into `FastMCP()`.** The lifespan was defined in `server.py` but never actually passed to the FastMCP constructor, so `BackgroundIndexer.run_loop()` never ran at server startup — despite the whole scraper/embedder pipeline being present in the codebase. Adding `lifespan=mcp_galaxy_lifespan` starts it correctly and shuts it down cleanly on server stop.

**2. Adds a persistent freshness gate.** New `IndexerState` primitive persists `{collection_name: iso_timestamp}` to `/app/state/last_indexed.json` (host-mounted via a new `./state:/app/state` volume). `GlobalRecommender` consults the gate before scraping each of the two global collections; if the timestamp is within `InformerTTLs.LIFESPAN` (7 days) the whole scrape+embed is skipped. Successful upsert writes the timestamp. Restart within a week = both collections skip = no more "delete+recreate collection while queries are hitting it" storms.

**3. Robust embedding path.** With `local_embed` pointed at self-hosted mxbai-embed-large (512-token context) instead of OpenAI (8k), Galaxy tool/workflow content that overflows the context caused ollama's OpenAI-compat adapter to 400 the entire batch. Fixes:
   - Content truncated to 1200 chars before embedding.
   - Batch-level failure now falls back to per-item embedding to isolate the offender(s) instead of losing the whole batch. Failed items get `None` sentinels which downstream code drops from the dataframe.
   - `LLMResponse.get_embeddings` handles `None` sentinels (was crashing on `np.array(raw)` before).
   - Progress logging: `Embedding N items across K batches of B`, then per-batch progress lines (every 10 batches for large runs) with batch index. No more silent 15-minute gaps during long embed cycles.

## Files

- `app/bioblend_server/informer/indexer_state.py` — new `IndexerState` primitive, atomic JSON writes, timezone-aware timestamps, graceful fallback on missing/malformed file.
- `app/bioblend_server/informer/global_rec.py` — `_collection_name` helper, `_skip_if_fresh` gate, `mark_indexed` on successful upsert.
- `app/bioblend_server/informer/manager.py` — content truncation, None-drop filtering, aligned df.
- `app/bioblend_server/informer/utils.py` — None-aware `get_embeddings`.
- `app/bioblend_server/server.py` — `lifespan=mcp_galaxy_lifespan` wiring.
- `app/llm_provider.py` — per-item retry on batch failure, batch-progress logging.
- `docker-compose.yml` — `./state:/app/state` mount.
- `.gitignore` — `state/`.
- `tests/MCP/test_indexer_state.py` — 9 unit tests (roundtrip, freshness windows, missing file, malformed json, malformed timestamp, non-dict json, atomic write cleanup, independent collection tracking).
- `tests/MCP/test_llm_provider.py` — updated `test_openai_embedding_model_error_retry` for the per-item fallback contract.

## Test plan (verified on hetzner staging 2026-08-05)

- [x] **Unit tests green** — 9 new IndexerState tests + updated per-item fallback assertion.
- [x] **Wiring works** — after rebuild, log shows `BackgroundIndexer: Background scraper loop started.` at startup, followed by `Scraping and Indexing Global Recommender metadata.` (never appeared before this branch).
- [x] **Workflows collection rebuilt** — `Successfully deleted collection: generic_galaxy_workflow` → `Collection created` → `content embedded and stored in generic_galaxy_workflow succefully.` (~2m for 548 items).
- [x] **Tools collection rebuilt** — same sequence for 16,811 items over 169 batches in ~1h 20m (~2 embeddings/sec sustained through ollama).
- [x] **Two dropped items handled cleanly** — batches 116 and 117 each had one 1200-char item that overflowed mxbai's context even after truncation. Log confirms `[batch X/169] per-item retry done (99/100 succeeded)`, followed by `Dropping 2 entities that failed to embed`, then `Embeddings generated successfully with size 1024 (16809 rows kept).` No traceback, no rollback.
- [x] **Dim fix confirmed on Qdrant** — before: `curl http://localhost:6555/collections/generic_galaxy_tool` returned `"size":1536` with 15,248 old points. After: `"size":1024` with ~16,809 fresh points. Same for `generic_galaxy_workflow`.
- [x] **Timestamp file written** — `sudo docker exec mcp-app cat /app/state/last_indexed.json` shows both entries with recent ISO timestamps.
- [x] **Freshness gate confirmed** — after a subsequent restart, log shows `Skipping scrape of generic_galaxy_workflow; last indexed at 2026-08-05T11:29:12.094103+00:00` before any scrape work is attempted. Second collection would show the same skip line for the same reason.
- [x] **Query path no longer surfaces dim mismatch** — real AI Assistant traffic hitting `get_galaxy_information_tool` during the rebuild returned results from user-scoped collection successfully; post-rebuild, `generic_galaxy_workflow` semantic search now returns hits instead of an `Unexpected Response: 400 (Bad Request) — Vector dimension error: expected dim: 1536, got 1024` traceback.
- [x] **Progress logging visible in `docker logs`** — every 10th batch emits a `Embedding progress: X/169 batches complete.` line; failed batches emit `[batch X/169] failed (100 items), retrying per-item to isolate offender(s)` immediately; single-item failures include the item length in the error. Confirmed by watching the ~1h 20m run in real time.

Throughput data captured under `docs/embed-timings.md` for future comparison across 7-day cycles.