### PR TITLE
Add k8s deploy workflows for mcp-xp (staging + production)

### DIFF
--- a/.github/workflows/cd-production-deployment.yml
+++ b/.github/workflows/cd-production-deployment.yml
@@ -1,0 +1,91 @@
+name: CD - Deploy mcp-xp to Kubernetes (production / app.rejuve.bio)
+
+on:
+  repository_dispatch:
+    types: [deploy-production]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Debug workflow info
+        run: |
+          echo "Event Type: ${{ github.event.action }}"
+          echo "Image Tag: ${{ github.event.client_payload.image_tag }}"
+          echo "Triggered by: ${{ github.actor }}"
+
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_PRODUCTION }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
+
+      - name: Deploy to Kubernetes
+        run: |
+          set -euo pipefail
+
+          NAMESPACE="mcp-xp-production"
+          TAG="${{ github.event.client_payload.image_tag }}"
+
+          if [ -z "$TAG" ]; then
+            TAG="production"
+          fi
+
+          echo "Using image tag: $TAG"
+
+          kubectl set image deployment/mcp-app \
+            mcp-app=rejuvebio/mcp-xp:${TAG} \
+            -n "$NAMESPACE"
+
+      - name: Wait for rollout
+        run: |
+          set -euo pipefail
+          kubectl rollout status deployment/mcp-app -n mcp-xp-production --timeout=180s
+
+      - name: Verify all pods
+        run: |
+          kubectl get pods -n mcp-xp-production
+
+      - name: Send success email
+        if: success()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline SUCCESS - mcp-xp Deployed to K8s (production)"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            mcp-xp deployment to Kubernetes production completed successfully!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+            Image tag: ${{ github.event.client_payload.image_tag }}
+
+            mcp-app pod updated and running in mcp-xp-production namespace.
+
+      - name: Send failure email
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline FAILED - mcp-xp K8s Deploy (production)"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            mcp-xp Kubernetes production deployment failed!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+            Image tag: ${{ github.event.client_payload.image_tag }}
+
+            Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/cd-production-deployment.yml
+++ b/.github/workflows/cd-production-deployment.yml
@@ -1,4 +1,4 @@
-name: CD - Deploy mcp-xp to Kubernetes (production / app.rejuve.bio)
+name: CD - Deploy mcp-xp to Kubernetes (production / app)
 
 on:
   repository_dispatch:

--- a/.github/workflows/cd-production-deployment.yml
+++ b/.github/workflows/cd-production-deployment.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [deploy-production]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/cd-staging-deployment.yml
+++ b/.github/workflows/cd-staging-deployment.yml
@@ -1,0 +1,91 @@
+name: CD - Deploy mcp-xp to Kubernetes (staging / hetzner)
+
+on:
+  repository_dispatch:
+    types: [deploy-staging]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Debug workflow info
+        run: |
+          echo "Event Type: ${{ github.event.action }}"
+          echo "Image Tag: ${{ github.event.client_payload.image_tag }}"
+          echo "Triggered by: ${{ github.actor }}"
+
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_STAGING }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
+
+      - name: Deploy to Kubernetes
+        run: |
+          set -euo pipefail
+
+          NAMESPACE="mcp-xp-staging"
+          TAG="${{ github.event.client_payload.image_tag }}"
+
+          if [ -z "$TAG" ]; then
+            TAG="staging"
+          fi
+
+          echo "Using image tag: $TAG"
+
+          kubectl set image deployment/mcp-app \
+            mcp-app=rejuvebio/mcp-xp:${TAG} \
+            -n "$NAMESPACE"
+
+      - name: Wait for rollout
+        run: |
+          set -euo pipefail
+          kubectl rollout status deployment/mcp-app -n mcp-xp-staging --timeout=180s
+
+      - name: Verify all pods
+        run: |
+          kubectl get pods -n mcp-xp-staging
+
+      - name: Send success email
+        if: success()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline SUCCESS - mcp-xp Deployed to K8s (staging)"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            mcp-xp deployment to Kubernetes staging completed successfully!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+            Image tag: ${{ github.event.client_payload.image_tag }}
+
+            mcp-app pod updated and running in mcp-xp-staging namespace.
+
+      - name: Send failure email
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "CD Pipeline FAILED - mcp-xp K8s Deploy (staging)"
+          to: ${{ secrets.RECIEVER_EMAIL }}
+          from: GitHub Actions <${{ secrets.EMAIL_USERNAME }}>
+          body: |
+            mcp-xp Kubernetes staging deployment failed!
+
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.actor }}
+            Image tag: ${{ github.event.client_payload.image_tag }}
+
+            Check logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/cd-staging-deployment.yml
+++ b/.github/workflows/cd-staging-deployment.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [deploy-staging]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,119 @@
+# Deploy workflows
+
+Two Kubernetes deploy workflows, mirroring the pattern used by
+`hypothesis-generation-demo`:
+
+| Workflow | Trigger event | Target namespace |
+|---|---|---|
+| `cd-staging-deployment.yml` | `repository_dispatch` type `deploy-staging` | `mcp-xp-staging` (hetzner cluster) |
+| `cd-production-deployment.yml` | `repository_dispatch` type `deploy-production` | `mcp-xp-production` (app.rejuve.bio cluster) |
+
+Both run on a **self-hosted runner** that has cluster network access
+and the `kubectl` binary available. Neither auto-deploys on push or
+merge — each requires an explicit `repository_dispatch` event.
+
+## How each deploy fires
+
+The workflow expects a `repository_dispatch` payload:
+
+```json
+{
+  "event_type": "deploy-staging",
+  "client_payload": { "image_tag": "sha-abc1234" }
+}
+```
+
+`image_tag` defaults to `"staging"` (or `"production"`) if the payload
+is empty.
+
+Typical trigger paths:
+
+**From a CI image-build workflow** (recommended once one exists):
+```yaml
+- uses: peter-evans/repository-dispatch@v3
+  with:
+    token: ${{ secrets.REPO_DISPATCH_PAT }}
+    repository: rejuve-bio/mcp-xp
+    event-type: deploy-staging
+    client-payload: '{"image_tag": "${{ needs.build.outputs.tag }}"}'
+```
+
+**Manually via `gh`**:
+```bash
+gh api /repos/rejuve-bio/mcp-xp/dispatches \
+  -f event_type=deploy-staging \
+  -f client_payload='{"image_tag":"sha-abc1234"}'
+```
+
+**Manually via curl**:
+```bash
+curl -X POST -H "Authorization: token <GITHUB_PAT>" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/rejuve-bio/mcp-xp/dispatches \
+  -d '{"event_type":"deploy-staging","client_payload":{"image_tag":"sha-abc1234"}}'
+```
+
+## What each workflow does
+
+1. Debug — echoes event type, image tag, and actor.
+2. Checkout the repo.
+3. Setup kubectl — writes the kubeconfig from the environment's secret
+   into `~/.kube/config`.
+4. `kubectl set image deployment/mcp-app mcp-app=rejuvebio/mcp-xp:$TAG
+   -n <namespace>` — updates the single mcp-xp deployment.
+5. `kubectl rollout status deployment/mcp-app -n <namespace>
+   --timeout=180s` — waits for the rollout to complete or fails at 3
+   minutes.
+6. `kubectl get pods -n <namespace>` — logs the current pod state.
+7. Success / failure email via `dawidd6/action-send-mail@v3`.
+
+## One-time setup
+
+### Required secrets (repo-level)
+
+| Secret | Purpose |
+|---|---|
+| `KUBECONFIG_STAGING` | full kubeconfig text pointing at the hetzner k8s cluster |
+| `KUBECONFIG_PRODUCTION` | full kubeconfig text pointing at the app.rejuve.bio k8s cluster |
+| `EMAIL_USERNAME`, `EMAIL_PASSWORD` | Gmail SMTP creds used by `action-send-mail` |
+| `RECIEVER_EMAIL` | recipient address for deploy notifications |
+
+### Required cluster state
+
+- A namespace `mcp-xp-staging` on the hetzner cluster with a Deployment
+  named `mcp-app` and a container `mcp-app` running the image
+  `rejuvebio/mcp-xp:staging`. `kubectl set image` only updates the
+  image reference on an existing Deployment; it doesn't create one.
+- Same shape on the production cluster in namespace
+  `mcp-xp-production` with the image tag `production`.
+- Whatever registry hosts `rejuvebio/mcp-xp` needs to be accessible
+  from both clusters (either public Docker Hub or a
+  `imagePullSecrets`-configured private registry).
+- A separate CI workflow that **builds and pushes** the docker image
+  before firing the dispatch (this repo currently has no such
+  workflow — you'll need to add one, or push images manually).
+
+### Self-hosted runner
+
+The workflows use `runs-on: self-hosted`. There needs to be at least
+one registered runner in this repo (or an org-level runner group the
+repo has access to) that has:
+
+- Network reachability to the two k8s clusters
+- `kubectl` installed
+- No secrets exposed via other jobs on the same runner
+
+Register a runner from Settings → Actions → Runners.
+
+## Rollback
+
+Re-fire the dispatch with the previous good tag:
+
+```bash
+gh api /repos/rejuve-bio/mcp-xp/dispatches \
+  -f event_type=deploy-staging \
+  -f client_payload='{"image_tag":"sha-<previous-good>"}'
+```
+
+State (Redis, Qdrant, the timestamp state file) is on persistent
+volumes and unaffected by the pod image change.


### PR DESCRIPTION
## Summary

Replaces the initial SSH/compose deploy attempt with k8s workflows that mirror `rejuve-bio/hypothesis-generation-demo` exactly:

- `cd-staging-deployment.yml` — `repository_dispatch` `deploy-staging` → `mcp-xp-staging` namespace (hetzner cluster)
- `cd-production-deployment.yml` — `repository_dispatch` `deploy-production` → `mcp-xp-production` namespace (app.rejuve.bio cluster)

Both run on `self-hosted` runners, load their kubeconfig from a secret, do `kubectl set image deployment/mcp-app mcp-app=rejuvebio/mcp-xp:<tag> -n <ns>`, wait for rollout with a 180s timeout, dump pod state, and send a success/failure email.

Neither triggers on push or merge — deploys need an explicit `repository_dispatch` event (from a CI image-build workflow or manually via `gh api /dispatches`).

## Setup required before either workflow can run

Add these repo-level secrets:

| Secret | Purpose |
|---|---|
| `KUBECONFIG_STAGING` | kubeconfig for the hetzner cluster |
| `KUBECONFIG_PRODUCTION` | kubeconfig for the app.rejuve.bio cluster |
| `EMAIL_USERNAME`, `EMAIL_PASSWORD` | Gmail SMTP creds for `action-send-mail` |
| `RECIEVER_EMAIL` | notification recipient |

Cluster state required:

- Namespace `mcp-xp-staging` on hetzner + `mcp-xp-production` on app, each with a Deployment named `mcp-app` containing a container `mcp-app` running the image `rejuvebio/mcp-xp:<tag>`. `kubectl set image` only updates an existing Deployment — it doesn't create one.
- Self-hosted runner registered on the repo with network reach to both clusters and `kubectl` installed.
- A separate CI workflow that builds/pushes the image (this repo doesn't have one yet — you'll need to add it, or push images manually).

Full setup in `docs/deploy.md`.

## Firing a deploy

```bash
gh api /repos/rejuve-bio/mcp-xp/dispatches \
  -f event_type=deploy-staging \
  -f client_payload='{"image_tag":"sha-abc1234"}'
```

Or from a CI image-build workflow via `peter-evans/repository-dispatch@v3`.

## Test plan

- [ ] Register a self-hosted runner and confirm it's picked up.
- [ ] Set repo secrets (kubeconfigs + email).
- [ ] Create the target Deployment on each cluster.
- [ ] Fire a staging dispatch and confirm the rollout completes + email arrives.
- [ ] Same for production.
- [ ] Confirm redeploying an older tag works (rollback path).